### PR TITLE
[REF] mass_mailing_custom_unsubscribe: Add tests

### DIFF
--- a/mass_mailing_custom_unsubscribe/controllers/main.py
+++ b/mass_mailing_custom_unsubscribe/controllers/main.py
@@ -9,7 +9,7 @@ from openerp.addons.mass_mailing.controllers.main import MassMailController
 from .. import exceptions as _ex
 
 
-class CustomUnsuscribe(MassMailController):
+class CustomUnsubscribe(MassMailController):
     def _mailing_list_contacts_by_email(self, email):
         """Gets the mailing list contacts by email.
 
@@ -228,7 +228,7 @@ class CustomUnsuscribe(MassMailController):
                     })
 
         # All is OK, unsubscribe
-        result = super(CustomUnsuscribe, self).mailing(
+        result = super(CustomUnsubscribe, self).mailing(
             mailing_id, email, res_id, **post)
         records.write({"success": result.data == "OK"})
 

--- a/mass_mailing_custom_unsubscribe/tests/__init__.py
+++ b/mass_mailing_custom_unsubscribe/tests/__init__.py
@@ -4,3 +4,4 @@
 
 from . import test_unsubscription
 from . import test_mail_mail
+from . import test_controller

--- a/mass_mailing_custom_unsubscribe/tests/__init__.py
+++ b/mass_mailing_custom_unsubscribe/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_unsubscription
+from . import test_mail_mail

--- a/mass_mailing_custom_unsubscribe/tests/test_controller.py
+++ b/mass_mailing_custom_unsubscribe/tests/test_controller.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+# © 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import mock
+from contextlib import contextmanager
+
+from openerp.tests.common import TransactionCase
+
+from openerp.addons.mass_mailing_custom_unsubscribe.controllers.main import (
+    CustomUnsubscribe
+)
+
+
+model = 'openerp.addons.mass_mailing_custom_unsubscribe.controllers.main'
+
+
+@contextmanager
+def mock_assets():
+    """ Mock & yield controller assets """
+    with mock.patch('%s.request' % model) as request:
+        yield {
+            'request': request,
+        }
+
+
+class EndTestException(Exception):
+    pass
+
+
+class TestController(TransactionCase):
+
+    def setUp(self):
+        super(TestController, self).setUp()
+        self.controller = CustomUnsubscribe()
+
+    def _default_domain(self):
+        return [
+            ('opt_out', '=', False),
+            ('list_id.not_cross_unsubscriptable', '=', False),
+        ]
+
+    def test_mailing_list_contacts_by_email_search(self):
+        """ It should search for contacts """
+        expect = 'email'
+        with mock_assets() as mk:
+            self.controller._mailing_list_contacts_by_email(expect)
+            model_obj = mk['request'].env['mail.mass_mailing.contact'].sudo()
+            model_obj.search.assert_called_once_with(
+                [('email', '=', expect)] + self._default_domain()
+            )
+
+    def test_mailing_list_contacts_by_email_return(self):
+        """ It should return result of search """
+        expect = 'email'
+        with mock_assets() as mk:
+            res = self.controller._mailing_list_contacts_by_email(expect)
+            model_obj = mk['request'].env['mail.mass_mailing.contact'].sudo()
+            self.assertEqual(
+                model_obj.search(), res,
+            )
+
+    def test_unsubscription_reason_gets_context(self):
+        """ It should retrieve unsub qcontext """
+        expect = 'mailing_id', 'email', 'res_id', 'token'
+        with mock_assets():
+            with mock.patch.object(
+                self.controller, 'unsubscription_qcontext'
+            ) as unsub:
+                unsub.side_effect = EndTestException
+                with self.assertRaises(EndTestException):
+                    self.controller.unsubscription_reason(*expect)
+                unsub.assert_called_once_with(*expect)
+
+    def test_unsubscription_updates_with_extra_context(self):
+        """ It should update qcontext with provided vals """
+        expect = 'mailing_id', 'email', 'res_id', 'token'
+        qcontext = {'context': 'test'}
+        with mock_assets():
+            with mock.patch.object(
+                self.controller, 'unsubscription_qcontext'
+            ) as unsub:
+                self.controller.unsubscription_reason(
+                    *expect, qcontext_extra=qcontext
+                )
+                unsub().update.assert_called_once_with(qcontext)
+
+    def test_unsubscription_updates_rendered_correctly(self):
+        """ It should correctly render website """
+        expect = 'mailing_id', 'email', 'res_id', 'token'
+        with mock_assets() as mk:
+            with mock.patch.object(
+                self.controller, 'unsubscription_qcontext'
+            ) as unsub:
+                self.controller.unsubscription_reason(*expect)
+                mk['request'].website.render.assert_called_once_with(
+                    "mass_mailing_custom_unsubscribe.reason_form",
+                    unsub(),
+                )
+
+    def test_unsubscription_updates_returns_site(self):
+        """ It should return website """
+        expect = 'mailing_id', 'email', 'res_id', 'token'
+        with mock_assets() as mk:
+            with mock.patch.object(
+                self.controller, 'unsubscription_qcontext'
+            ):
+                res = self.controller.unsubscription_reason(*expect)
+                self.assertEqual(
+                    mk['request'].website.render(), res
+                )

--- a/mass_mailing_custom_unsubscribe/tests/test_mail_mail.py
+++ b/mass_mailing_custom_unsubscribe/tests/test_mail_mail.py
@@ -65,6 +65,7 @@ class TestMailMail(TransactionCase):
     def test_get_unsubscribe_url_false_config_msg(self, urllib, urlparse):
         """ It should return default config msg when none supplied """
         expects = ['uri', False]
+        urlparse.urljoin.return_value = expects[0]
         with mock.patch.object(self.Model, 'env') as env:
             env['ir.config_paramater'].get_param.side_effect = expects
             res = self.Model._get_unsubscribe_url(
@@ -84,6 +85,7 @@ class TestMailMail(TransactionCase):
     def test_get_unsubscribe_url_with_config_msg(self, urllib, urlparse):
         """ It should return config message w/ URL formatted """
         expects = ['uri', 'test %(url)s']
+        urlparse.urljoin.return_value = expects[0]
         with mock.patch.object(self.Model, 'env') as env:
             env['ir.config_paramater'].get_param.side_effect = expects
             res = self.Model._get_unsubscribe_url(

--- a/mass_mailing_custom_unsubscribe/tests/test_mail_mail.py
+++ b/mass_mailing_custom_unsubscribe/tests/test_mail_mail.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# © 2016 LasLabs Inc.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import mock
+
+from openerp.tests.common import TransactionCase
+
+
+model = 'openerp.addons.mass_mailing_custom_unsubscribe.models.mail_mail'
+
+
+class EndTestException(Exception):
+    pass
+
+
+class TestMailMail(TransactionCase):
+
+    def setUp(self):
+        super(TestMailMail, self).setUp()
+        self.Model = self.env['mail.mail']
+        param_obj = self.env['ir.config_parameter']
+        self.base_url = param_obj.get_param('web.base.url')
+        self.config_msg = param_obj.get_param(
+            'mass_mailing.unsubscribe.label'
+        )
+
+    @mock.patch('%s.urlparse' % model)
+    @mock.patch('%s.urllib' % model)
+    def test_get_unsubscribe_url_proper_url(self, urllib, urlparse):
+        """ It should join the URL w/ proper args """
+        urlparse.urljoin.side_effect = EndTestException
+        expect = mock.MagicMock(), 'email', 'msg'
+        with self.assertRaises(EndTestException):
+            self.Model._get_unsubscribe_url(*expect)
+        urlparse.urljoin.assert_called_once_with(
+            self.base_url,
+            'mail/mailing/%(mailing_id)s/unsubscribe?%(params)s' % {
+                'mailing_id': expect[0].mailing_id.id,
+                'params': urllib.urlencode(),
+            }
+        )
+
+    @mock.patch('%s.urlparse' % model)
+    @mock.patch('%s.urllib' % model)
+    def test_get_unsubscribe_url_correct_params(self, urllib, urlparse):
+        """ It should create URL params w/ proper data """
+        urlparse.urljoin.side_effect = EndTestException
+        expect = mock.MagicMock(), 'email', 'msg'
+        with self.assertRaises(EndTestException):
+            self.Model._get_unsubscribe_url(*expect)
+        urllib.urlencode.assert_called_once_with(dict(
+            db=self.env.cr.dbname,
+            res_id=expect[0].res_id,
+            email=expect[1],
+            token=self.env['mail.mass_mailing'].hash_create(
+                expect[0].mailing_id.id,
+                expect[0].res_id,
+                expect[1],
+            )
+        ))
+
+    @mock.patch('%s.urlparse' % model)
+    @mock.patch('%s.urllib' % model)
+    def test_get_unsubscribe_url_false_config_msg(self, urllib, urlparse):
+        """ It should return default config msg when none supplied """
+        expects = ['uri', False]
+        with mock.patch.object(self.Model, 'env') as env:
+            env['ir.config_paramater'].get_param.side_effect = expects
+            res = self.Model._get_unsubscribe_url(
+                mock.MagicMock(), 'email', 'msg'
+            )
+            self.assertIn(
+                expects[0], res,
+                'Did not include URI in default message'
+            )
+            self.assertIn(
+                'msg', res,
+                'Did not include input msg in default message'
+            )
+
+    @mock.patch('%s.urlparse' % model)
+    @mock.patch('%s.urllib' % model)
+    def test_get_unsubscribe_url_with_config_msg(self, urllib, urlparse):
+        """ It should return config message w/ URL formatted """
+        expects = ['uri', 'test %(url)s']
+        with mock.patch.object(self.Model, 'env') as env:
+            env['ir.config_paramater'].get_param.side_effect = expects
+            res = self.Model._get_unsubscribe_url(
+                mock.MagicMock(), 'email', 'msg'
+            )
+            self.assertEqual(
+                expects[1] % {'url': expects[0]}, res,
+                'Did not return proper config message'
+            )


### PR DESCRIPTION
This adds test coverage for mass_mailing_custom_unsubscribe model and some of the controller. It also fixes a misspelling of the controller name.
